### PR TITLE
Replace deprecated Module.eval_quoted/2 in __before_compile__ with AST return

### DIFF
--- a/lib/tags_multi_tenant/tag_as.ex
+++ b/lib/tags_multi_tenant/tag_as.ex
@@ -78,49 +78,45 @@ defmodule TagsMultiTenant.TagAs do
     end
   end
 
-  defmacro __before_compile__(_env) do
-    quote do
-      @contexts
-      |> Enum.each(fn context ->
-        singularized_context = Inflex.singularize(context)
+  defmacro __before_compile__(env) do
+    contexts = Module.get_attribute(env.module, :contexts) || []
 
-        Module.eval_quoted(
-          __MODULE__,
-          quote do
-            def unquote(:"add_#{context}")(tags) do
-              TagsMultiTenant.add(%__MODULE__{}, tags, unquote(context), [])
-            end
+    for context <- contexts do
+      singularized_context = Inflex.singularize(context)
 
-            def unquote(:"add_#{context}")(tags, opts) do
-              TagsMultiTenant.add(%__MODULE__{}, tags, unquote(context), opts)
-            end
+      quote do
+        def unquote(:"add_#{context}")(tags) do
+          TagsMultiTenant.add(%__MODULE__{}, tags, unquote(context), [])
+        end
 
-            def unquote(:"add_#{singularized_context}")(tags) do
-              TagsMultiTenant.add(%__MODULE__{}, tags, unquote(context), [])
-            end
+        def unquote(:"add_#{context}")(tags, opts) do
+          TagsMultiTenant.add(%__MODULE__{}, tags, unquote(context), opts)
+        end
 
-            def unquote(:"add_#{singularized_context}")(tags, opts) do
-              TagsMultiTenant.add(%__MODULE__{}, tags, unquote(context), opts)
-            end
+        def unquote(:"add_#{singularized_context}")(tags) do
+          TagsMultiTenant.add(%__MODULE__{}, tags, unquote(context), [])
+        end
 
-            def unquote(:"remove_#{singularized_context}")(tag) do
-              TagsMultiTenant.remove(%__MODULE__{}, tag, unquote(context), [])
-            end
+        def unquote(:"add_#{singularized_context}")(tags, opts) do
+          TagsMultiTenant.add(%__MODULE__{}, tags, unquote(context), opts)
+        end
 
-            def unquote(:"remove_#{singularized_context}")(tag, opts) do
-              TagsMultiTenant.remove(%__MODULE__{}, tag, unquote(context), opts)
-            end
+        def unquote(:"remove_#{singularized_context}")(tag) do
+          TagsMultiTenant.remove(%__MODULE__{}, tag, unquote(context), [])
+        end
 
-            def unquote(:"rename_#{singularized_context}")(old_tag, new_tag) do
-              TagsMultiTenant.rename(%__MODULE__{}, old_tag, new_tag, unquote(context), [])
-            end
+        def unquote(:"remove_#{singularized_context}")(tag, opts) do
+          TagsMultiTenant.remove(%__MODULE__{}, tag, unquote(context), opts)
+        end
 
-            def unquote(:"rename_#{singularized_context}")(old_tag, new_tag, opts) do
-              TagsMultiTenant.rename(%__MODULE__{}, old_tag, new_tag, unquote(context), opts)
-            end
-          end
-        )
-      end)
+        def unquote(:"rename_#{singularized_context}")(old_tag, new_tag) do
+          TagsMultiTenant.rename(%__MODULE__{}, old_tag, new_tag, unquote(context), [])
+        end
+
+        def unquote(:"rename_#{singularized_context}")(old_tag, new_tag, opts) do
+          TagsMultiTenant.rename(%__MODULE__{}, old_tag, new_tag, unquote(context), opts)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Elixir 1.18 deprecated `Module.eval_quoted/2`. The current `TagsMultiTenant.TagAs.__before_compile__/1` macro emits eight deprecation warnings per host module that uses `TagAs` with two contexts; any project on Elixir 1.18+ that consumes this library sees a noisy compile.

## What changes

- `__before_compile__/1` no longer wraps everything in `quote do ... end` and `Enum.each`-es over `@contexts` at host-module compile time.
- Instead it reads `@contexts` via `Module.get_attribute(env.module, :contexts)` at macro-expansion time, iterates with a comprehension, and returns a list of quoted blocks.
- The compiler injects each block into the host module — same end state as before.
- One parameter rename: `_env` → `env` (now used).

## Behavior

Identical. The generated functions, their names, their arities, their dispatch, and the multi-context accumulator semantics are unchanged.

## Compatibility

Works on all currently supported Elixir versions (1.14+). `Module.get_attribute/2` and the AST-list return from `__before_compile__/1` have been stable Elixir public API for years. The change does not require Elixir 1.18 — it's just the version that started warning loudly.

## Test plan

- Verified on a downstream consumer (multi-tenant Phoenix app, four schemas using `use TagsMultiTenant.TagAs, :tags`) under Elixir 1.18.4 / OTP 27: zero `Module.eval_quoted` deprecation warnings, all generated tagging functions resolve correctly at runtime, full tag-related test suite passes.
- I was unable to run this fork's own `mix test` because the lockfile pins `ecto 3.9.2`, which conflicts with `dynamic/0` becoming a built-in type in Elixir 1.17+. Happy to bump the lockfile in a separate PR if helpful.

## Notes for maintainer

The hex package was last published 2023-09-18 (v0.1.17). If you'd accept this PR, consumers on current Elixir would appreciate a v0.1.18 cut.